### PR TITLE
Update for Qt6 compatibility

### DIFF
--- a/src/qdlg/qdlg.py
+++ b/src/qdlg/qdlg.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5.Qt import QDialog, QVBoxLayout, Qt
+from aqt.qt import QDialog, QVBoxLayout, Qt
 
 from .stack import pushQDlgStack, popQDlgStack, qDlgStackGetDialog
 from .utils import addLayoutOrWidget
@@ -31,7 +31,7 @@ def QDlg(title, size=None):
                 onClose(accepted): Function to run on close. Defaults to None.
             """
             dlg = QDialog()
-            dlg.setWindowFlags(dlg.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+            dlg.setWindowFlags(dlg.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
             dlg.setWindowTitle(title)
 
             layout = QVBoxLayout()
@@ -43,7 +43,7 @@ def QDlg(title, size=None):
             self.constructor(dlg, *args, **kwargs)
             popQDlgStack(self)
 
-            dlg.setWindowModality(Qt.WindowModal)
+            dlg.setWindowModality(Qt.WindowModality.WindowModal)
             if size:
                 dlg.resize(size[0], size[1])
             dlg.show()

--- a/src/qdlg/utils.py
+++ b/src/qdlg/utils.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5.Qt import QLayout, QWidget
+from aqt.qt import QLayout, QWidget
 
 
 def addLayoutOrWidget(layout, child):

--- a/src/qdlg/widgets/Button.py
+++ b/src/qdlg/widgets/Button.py
@@ -17,7 +17,7 @@ from ..stack import qDlgStackTop
 from .Style import StylableWidget
 from .Shortcutable import Shortcutable
 
-from PyQt5.Qt import QPushButton, QKeySequence
+from aqt.qt import QPushButton, QKeySequence
 
 
 class Button(StylableWidget, Shortcutable):

--- a/src/qdlg/widgets/CheckBox.py
+++ b/src/qdlg/widgets/CheckBox.py
@@ -19,7 +19,7 @@ from ..modelHandler import configureModel
 from .Style import StylableWidget
 from .Shortcutable import Shortcutable
 
-from PyQt5.Qt import QCheckBox
+from aqt.qt import QCheckBox
 
 
 class CheckBox(StylableWidget, Shortcutable):

--- a/src/qdlg/widgets/Group.py
+++ b/src/qdlg/widgets/Group.py
@@ -17,7 +17,7 @@ from ..stack import qDlgStackTop
 from ..utils import addLayoutOrWidget
 from ..container import QDlgContainer
 
-from PyQt5.Qt import QGroupBox, QVBoxLayout
+from aqt.qt import QGroupBox, QVBoxLayout
 
 
 class Group(QDlgContainer):

--- a/src/qdlg/widgets/LineEdit.py
+++ b/src/qdlg/widgets/LineEdit.py
@@ -18,7 +18,7 @@ from ..utils import continuationHelper
 from ..modelHandler import configureModel
 from .Style import StylableWidget
 
-from PyQt5.Qt import QLineEdit
+from aqt.qt import QLineEdit
 
 
 class LineEdit(StylableWidget):

--- a/src/qdlg/widgets/ListBox.py
+++ b/src/qdlg/widgets/ListBox.py
@@ -20,7 +20,7 @@ from ..observable import isObservable
 from ..modelHandler import configureModel
 from .Style import StylableWidget
 
-from PyQt5.Qt import QListWidget, QListWidgetItem, Qt, QPoint, QAbstractItemView
+from aqt.qt import QListWidget, QListWidgetItem, Qt, QPoint, QAbstractItemView
 
 from typing import Union, List, Any
 

--- a/src/qdlg/widgets/RadioButton.py
+++ b/src/qdlg/widgets/RadioButton.py
@@ -18,7 +18,7 @@ from ..utils import continuationHelper
 from ..modelHandler import configureModel
 from .Style import StylableWidget
 
-from PyQt5.Qt import QRadioButton
+from aqt.qt import QRadioButton
 
 
 class RadioButton(StylableWidget):

--- a/src/qdlg/widgets/Shortcutable.py
+++ b/src/qdlg/widgets/Shortcutable.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5.Qt import QKeySequence
+from aqt.qt import QKeySequence
 
 
 class Shortcutable:

--- a/src/qdlg/widgets/Table.py
+++ b/src/qdlg/widgets/Table.py
@@ -17,7 +17,7 @@ from ..stack import qDlgStackTop
 from ..container import QDlgContainer
 from ..utils import addLayoutOrWidget
 
-from PyQt5.Qt import QGridLayout, QVBoxLayout
+from aqt.qt import QGridLayout, QVBoxLayout
 
 
 class Td(QDlgContainer):

--- a/src/qdlg/widgets/Text.py
+++ b/src/qdlg/widgets/Text.py
@@ -16,7 +16,7 @@
 from ..stack import qDlgStackTop
 from .Style import StylableWidget
 
-from PyQt5.Qt import QLabel
+from aqt.qt import QLabel
 
 
 class Text(StylableWidget):

--- a/src/qdlg/widgets/layout.py
+++ b/src/qdlg/widgets/layout.py
@@ -17,7 +17,7 @@ from ..stack import qDlgStackTop
 from ..container import QDlgContainer
 from ..utils import addLayoutOrWidget
 
-from PyQt5.Qt import QVBoxLayout, QHBoxLayout
+from aqt.qt import QVBoxLayout, QHBoxLayout
 
 
 class LayoutBase(QDlgContainer):

--- a/src/tests/test_qdlg/q_accept_reject.py
+++ b/src/tests/test_qdlg/q_accept_reject.py
@@ -18,7 +18,7 @@ from qdlgproxy import (  # type: ignore
     QDlg,
     Button,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 @QDlg("OK/reject test")

--- a/src/tests/test_qdlg/q_button.py
+++ b/src/tests/test_qdlg/q_button.py
@@ -15,7 +15,7 @@
 
 import sys
 from qdlgproxy import QDlg, Text, Button  # type: ignore
-from PyQt5.Qt import QApplication, QMessageBox
+from aqt.qt import QApplication, QMessageBox
 
 
 @QDlg("Test dialog", size=[640, 480])

--- a/src/tests/test_qdlg/q_checkbox.py
+++ b/src/tests/test_qdlg/q_checkbox.py
@@ -25,7 +25,7 @@ from qdlgproxy import (  # type: ignore
     Tr,
     Td,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 class TestClass:

--- a/src/tests/test_qdlg/q_configurator.py
+++ b/src/tests/test_qdlg/q_configurator.py
@@ -26,7 +26,7 @@ from qdlgproxy import (
     Td,
 )
 
-from PyQt5.Qt import QApplication, QAbstractItemView
+from aqt.qt import QApplication, QAbstractItemView
 import sys
 
 # # Word autocompltete - configuration

--- a/src/tests/test_qdlg/q_group.py
+++ b/src/tests/test_qdlg/q_group.py
@@ -24,7 +24,7 @@ from qdlgproxy import (  # type: ignore
     Td,
     Group,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 @QDlg("Table test")

--- a/src/tests/test_qdlg/q_lineedit.py
+++ b/src/tests/test_qdlg/q_lineedit.py
@@ -15,7 +15,7 @@
 
 import sys
 from qdlgproxy import QDlg, Text, LineEdit  # type: ignore
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 @QDlg("LineEdit test dialog", size=[640, 480])

--- a/src/tests/test_qdlg/q_listbox.py
+++ b/src/tests/test_qdlg/q_listbox.py
@@ -15,7 +15,7 @@
 
 import sys
 from qdlgproxy import QDlg, ListBox, observable
-from PyQt5.Qt import QApplication, QAbstractItemView
+from aqt.qt import QApplication, QAbstractItemView
 
 
 class TestClass:

--- a/src/tests/test_qdlg/q_model.py
+++ b/src/tests/test_qdlg/q_model.py
@@ -27,7 +27,7 @@ from qdlgproxy import (  # type: ignore
     Td,
     observable,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 class TestClass:

--- a/src/tests/test_qdlg/q_radiobutton.py
+++ b/src/tests/test_qdlg/q_radiobutton.py
@@ -18,7 +18,7 @@ from qdlgproxy import (  # type: ignore
     QDlg,
     RadioButton,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 @QDlg("Table test")

--- a/src/tests/test_qdlg/q_style.py
+++ b/src/tests/test_qdlg/q_style.py
@@ -19,7 +19,7 @@ from qdlgproxy import (  # type: ignore
     Button,
     HStack,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 style = """
     QPushButton {

--- a/src/tests/test_qdlg/q_table.py
+++ b/src/tests/test_qdlg/q_table.py
@@ -23,7 +23,7 @@ from qdlgproxy import (  # type: ignore
     Tr,
     Td,
 )
-from PyQt5.Qt import QApplication
+from aqt.qt import QApplication
 
 
 @QDlg("Table test")

--- a/src/utils/MiniBrowser.py
+++ b/src/utils/MiniBrowser.py
@@ -38,8 +38,8 @@ class MiniBrowser(QDialog):
         super().__init__(parent)
         mw.setupDialogGC(self)
 
-        self.setWindowFlags(Qt.Window)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(Qt.WindowType.Window)
+        self.setWindowModality(Qt.WindowModality.WindowModal)
 
         # Populate content
         self.web = AnkiWebView()


### PR DESCRIPTION
The Qt5 compatibility layer is disabled by default in Anki 23.10

Closes #5